### PR TITLE
fix: yarn build stylelint error

### DIFF
--- a/wp-content/themes/adelanteandalucia/resources/assets/styles/components/_buttons.scss
+++ b/wp-content/themes/adelanteandalucia/resources/assets/styles/components/_buttons.scss
@@ -40,12 +40,12 @@
 
   &--primary {
     padding: gap(3) gap(4);
-    color: var(--primary--dark);
+    color: var(--primary-dark);
     background-color: var(--primary);
 
     svg {
       path {
-        fill: var(--primary--dark);
+        fill: var(--primary-dark);
       }
     }
 


### PR DESCRIPTION
Corrige un error al ejecutar:

`yarn build`

Causado por un error en el nombre de una variable Sass.