### PR TITLE
fix: deprecated hook allowed_block_types

### DIFF
--- a/wp-content/themes/adelanteandalucia/app/filters.php
+++ b/wp-content/themes/adelanteandalucia/app/filters.php
@@ -133,7 +133,7 @@ add_action('init', function () {
 /**
  * Disable Gutenberg core blocks
  */
-add_filter('allowed_block_types', function ($allowed_blocks) {
+add_filter('allowed_block_types_all', function ($allowed_blocks) {
     return [
         'acf/intro',
         'acf/cta',


### PR DESCRIPTION
Actualiza hook obsoleto.

https://developer.wordpress.org/reference/hooks/allowed_block_types/
https://developer.wordpress.org/reference/hooks/allowed_block_types_all/