### PR TITLE
use array_slice() instead of end()

### DIFF
--- a/wp-content/themes/adelanteandalucia/app/filters.php
+++ b/wp-content/themes/adelanteandalucia/app/filters.php
@@ -163,7 +163,7 @@ add_filter('excerpt_length', function() { return 20; }, 10);
 //exclude sticky from home blog query
 add_action('pre_get_posts', function($query) {
     if ($query->is_home() && $query->is_main_query()) {
-        $query->set('post__not_in', [end(get_option('sticky_posts'))]);
+        $query->set('post__not_in', array_slice(get_option('sticky_posts'), -1));
     }
     $query->set('ignore_sticky_posts', true);
 });


### PR DESCRIPTION
Devuelve el último elemento del array pero evita el error:

`PHP Notice:  Only variables should be passed by reference in /var/www/html/wp-content/themes/adelanteandalucia/app/filters.php on line 166`