### PR TITLE
add object-fit property to footer logo

### DIFF
--- a/wp-content/themes/adelanteandalucia/resources/assets/styles/layouts/_footer.scss
+++ b/wp-content/themes/adelanteandalucia/resources/assets/styles/layouts/_footer.scss
@@ -18,6 +18,7 @@
     display: block;
     max-width: 150px;
     margin: 0 0 gap(6) 0;
+    object-fit: contain;
   }
 
   &__social {

--- a/wp-content/themes/adelanteandalucia/resources/assets/styles/layouts/_footer.scss
+++ b/wp-content/themes/adelanteandalucia/resources/assets/styles/layouts/_footer.scss
@@ -12,13 +12,13 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+    align-items: flex-start;
   }
 
   &__logo {
     display: block;
     max-width: 150px;
     margin: 0 0 gap(6) 0;
-    object-fit: contain;
   }
 
   &__social {


### PR DESCRIPTION
Al usar `display: block` en un `<img />` conviene añadir `object-fit: contain` para evitar que distorsione la imagen.